### PR TITLE
test(ktorgen-compiler): add unit test for all options in KtorGen and KtorGenFunction

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -28,6 +28,7 @@ kotlin {
 
 dependencies {
     implementation(projects.annotations)
+    implementation(kotlin("reflect"))
     implementation(libs.ksp.api)
     implementation(libs.kotlin.poet)
     implementation(libs.kotlin.poet.ksp)

--- a/compiler/src/main/kotlin/io/github/kingg22/ktorgen/DiagnosticSender.kt
+++ b/compiler/src/main/kotlin/io/github/kingg22/ktorgen/DiagnosticSender.kt
@@ -30,7 +30,7 @@ interface DiagnosticSender {
     fun addError(message: String, symbol: KSNode? = null)
 
     /** Fatal error, can be related to a symbol. This is a controlled exception. */
-    fun die(message: String, symbol: KSNode? = null): Nothing
+    fun die(message: String, symbol: KSNode? = null, exception: Exception?): Nothing
 }
 
 /** Run all the work in try-catch-finally, this handle start finish and die when throw exceptions */
@@ -40,18 +40,18 @@ inline fun <R> DiagnosticSender.work(block: (DiagnosticSender) -> R): R = try {
     finish()
     result
 } catch (e: Exception) {
-    die(e.message ?: "", null)
+    die(e.message ?: "", null, e)
 }
 
 /** If the condition is false, die */
 @Suppress("NOTHING_TO_INLINE")
 inline fun DiagnosticSender.require(condition: Boolean, message: String, symbol: KSNode? = null) {
-    if (!condition) die(message, symbol)
+    if (!condition) die(message, symbol, null)
 }
 
 /** If the value is null, die */
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> DiagnosticSender.requireNotNull(value: T?, message: String, symbol: KSNode? = null): T {
-    if (value == null) die(message, symbol)
+    if (value == null) die(message, symbol, null)
     return value
 }

--- a/compiler/src/main/kotlin/io/github/kingg22/ktorgen/DiagnosticTimer.kt
+++ b/compiler/src/main/kotlin/io/github/kingg22/ktorgen/DiagnosticTimer.kt
@@ -61,7 +61,8 @@ class DiagnosticTimer(name: String, private val onDebugLog: (String) -> Unit) : 
     override fun addStep(message: String, symbol: KSNode?) = root.addStep(message, symbol)
     override fun addWarning(message: String, symbol: KSNode?) = root.addWarning(message, symbol)
     override fun addError(message: String, symbol: KSNode?) = root.addError(message, symbol)
-    override fun die(message: String, symbol: KSNode?): Nothing = root.die(message, symbol)
+    override fun die(message: String, symbol: KSNode?, exception: Exception?): Nothing =
+        root.die(message, symbol, exception)
 
     private fun StringBuilder.printStep(step: Step, indent: String) {
         val icon = iconFor(step)
@@ -165,7 +166,7 @@ class DiagnosticTimer(name: String, private val onDebugLog: (String) -> Unit) : 
             messages.add(DiagnosticMessage(MessageType.ERROR, message.trim(), symbol))
         }
 
-        override fun die(message: String, symbol: KSNode?): Nothing {
+        override fun die(message: String, symbol: KSNode?, exception: Exception?): Nothing {
             messages.add(DiagnosticMessage(MessageType.ERROR, message.trim(), symbol))
             var suppressException: Throwable? = null
 
@@ -178,7 +179,7 @@ class DiagnosticTimer(name: String, private val onDebugLog: (String) -> Unit) : 
             } catch (e: Throwable) {
                 suppressException = e
             }
-            val exception = Throwable("Fatal error occurred. \n${buildErrorsAndWarningsMessage()}")
+            val exception = Throwable("Fatal error occurred. \n${buildErrorsAndWarningsMessage()}", exception)
             suppressException?.let { exception.addSuppressed(suppressException) }
             throw exception
         }

--- a/compiler/src/main/kotlin/io/github/kingg22/ktorgen/KtorGenProcessor.kt
+++ b/compiler/src/main/kotlin/io/github/kingg22/ktorgen/KtorGenProcessor.kt
@@ -98,13 +98,14 @@ class KtorGenProcessor(private val env: SymbolProcessorEnvironment, private val 
             if (validClassData.isNotEmpty()) timer.addStep("Generated ${validClassData.size} classes")
         } catch (e: Exception) {
             logger.fatalError("${KtorGenLogger.KTOR_GEN} Unexcepted exception caught. \n$e")
+            logger.exception(e)
         } catch (e: Throwable) {
             if (e.message == null) {
-                logger.exception(e)
                 logger.error("${KtorGenLogger.KTOR_GEN} Unknown exception caught as Throwable. \n $e")
             } else {
                 logger.error(e.message!!, null)
             }
+            logger.exception(e)
         }
 
         if (deferredSymbols.isNotEmpty()) {

--- a/compiler/src/main/kotlin/io/github/kingg22/ktorgen/extractor/KspExt.kt
+++ b/compiler/src/main/kotlin/io/github/kingg22/ktorgen/extractor/KspExt.kt
@@ -4,6 +4,8 @@
 
 package io.github.kingg22.ktorgen.extractor
 
+import com.google.devtools.ksp.KSTypeNotPresentException
+import com.google.devtools.ksp.KSTypesNotPresentException
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -38,6 +40,10 @@ inline fun <reified A : Annotation, R : Any> KSAnnotated.getAnnotation(
         this.getAnnotationsByType(A::class).singleOrNull()?.let(mapFromAnnotation)
     } catch (_: NoSuchElementException) {
         this.annotations.singleOrNull { it.shortName.getShortName() == A::class.simpleName!! }?.let(manualExtraction)
+    } catch (_: KSTypeNotPresentException) {
+        this.annotations.singleOrNull { it.shortName.getShortName() == A::class.simpleName!! }?.let(manualExtraction)
+    } catch (_: KSTypesNotPresentException) {
+        this.annotations.singleOrNull { it.shortName.getShortName() == A::class.simpleName!! }?.let(manualExtraction)
     }
 }
 
@@ -48,6 +54,10 @@ inline fun <reified A : Annotation, R : Any> KSAnnotated.getAllAnnotation(
 ): Sequence<R> = try {
     this.getAnnotationsByType(A::class).map(mapFromAnnotation)
 } catch (_: NoSuchElementException) {
+    this.annotations.filter { it.shortName.getShortName() == A::class.simpleName!! }.map(manualExtraction)
+} catch (_: KSTypeNotPresentException) {
+    this.annotations.filter { it.shortName.getShortName() == A::class.simpleName!! }.map(manualExtraction)
+} catch (_: KSTypesNotPresentException) {
     this.annotations.filter { it.shortName.getShortName() == A::class.simpleName!! }.map(manualExtraction)
 }
 

--- a/compiler/src/main/kotlin/io/github/kingg22/ktorgen/generator/KotlinpoetGenerator.kt
+++ b/compiler/src/main/kotlin/io/github/kingg22/ktorgen/generator/KotlinpoetGenerator.kt
@@ -42,15 +42,6 @@ class KotlinpoetGenerator : KtorGenGenerator {
 
         timer.addStep("Generated primary constructor and properties, going to generate ${functions.size} functions")
 
-        // optimize generation if not going to generate util code
-        // no have functions to overrides
-        // one property is HttpClient, no have properties to override
-        val goingToGenerate = functions.isNotEmpty() || properties.size > 1
-
-        if (!goingToGenerate) {
-            return@work KtorGenGenerator.NO_OP.generate(classData, timer.createTask("Dummy code"))
-        }
-
         // add super interfaces, constructor and properties
         classBuilder
             .addSuperInterfaces(classData, constructor)

--- a/compiler/src/main/kotlin/io/github/kingg22/ktorgen/model/FunctionData.kt
+++ b/compiler/src/main/kotlin/io/github/kingg22/ktorgen/model/FunctionData.kt
@@ -12,7 +12,7 @@ class FunctionData(
     val parameterDataList: List<ParameterData>,
     val ktorGenAnnotations: List<FunctionAnnotation>,
     val ksFunctionDeclaration: KSFunctionDeclaration,
-    val isSuspend: Boolean = false,
+    val isSuspend: Boolean,
     val modifierSet: Set<KModifier>,
     val isImplemented: Boolean,
     options: FunctionGenerationOptions,

--- a/compiler/src/test/kotlin/io/github/kingg22/ktorgen/IntegrationTest.kt
+++ b/compiler/src/test/kotlin/io/github/kingg22/ktorgen/IntegrationTest.kt
@@ -62,4 +62,25 @@ class IntegrationTest {
             compilationResultSubject.hasErrorCount(0)
         }
     }
+
+    @Test
+    fun privateInterfaceCantGeneratedThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen
+                private interface TestService
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) {
+            it.hasNoWarnings()
+            it.hasErrorCount(1)
+            it.hasErrorContaining(KtorGenLogger.PRIVATE_INTERFACE_CANT_GENERATE.trim())
+        }
+    }
 }

--- a/compiler/src/test/kotlin/io/github/kingg22/ktorgen/KtorGenFunctionTest.kt
+++ b/compiler/src/test/kotlin/io/github/kingg22/ktorgen/KtorGenFunctionTest.kt
@@ -1,9 +1,12 @@
 package io.github.kingg22.ktorgen
 
 import androidx.room.compiler.processing.util.Source
+import io.github.kingg22.ktorgen.model.KTORG_GENERATED_COMMENT
 import kotlin.test.Test
 
+/** Test related to [@KtorGenFunction][io.github.kingg22.ktorgen.core.KtorGenFunction] annotation */
 class KtorGenFunctionTest {
+    // -- propagate annotation --
     @Test
     fun testOptInAnnotationIsPropagatedInFunctionGenerated() {
         val source = Source.kotlin(
@@ -70,6 +73,7 @@ class KtorGenFunctionTest {
         }
     }
 
+    // -- optIn annotations --
     @Test
     fun testRequiredOptInAnnotationIsPropagatedInFunctionGeneratedWithOptInOption() {
         val source = Source.kotlin(
@@ -102,6 +106,201 @@ class KtorGenFunctionTest {
             val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
             generatedFile.contains(expectedHeadersArgumentText)
             generatedFile.doesNotContain(noExpectedHeadersArgumentText)
+        }
+    }
+
+    // -- generate? --
+    @Test
+    fun testGenerateFalseDontGenerateFunction() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGenFunction
+                import io.github.kingg22.ktorgen.http.GET
+                import io.github.kingg22.ktorgen.http.Header
+
+                interface TestService {
+                    @KtorGenFunction(generate = false)
+                    @Header("x", "y")
+                    @GET("posts")
+                    suspend fun test(): String = "test"
+                }
+            """.trimIndent(),
+        )
+
+        val expectedText = listOf("public class _TestServiceImpl", ": TestService")
+        val nonExpectedText = listOf("override suspend fun test(): String")
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+
+            for (expectedLine in expectedText) {
+                generatedFile.contains(expectedLine)
+            }
+            for (nonExpectedLine in nonExpectedText) {
+                generatedFile.doesNotContain(nonExpectedLine)
+            }
+        }
+    }
+
+    /**
+     * When a function is declared on an interface, for implemented classes is mandatory to override it,
+     * the processor should throw an error if the generated file does not override it == no compile
+     */
+    @Test
+    fun testGenerateFalseAndMandatoryFunctionThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGenFunction
+                import io.github.kingg22.ktorgen.http.GET
+
+                interface TestService {
+                    @KtorGenFunction(generate = false)
+                    @GET("posts")
+                    suspend fun test(): String
+
+                    @GET("posts")
+                    suspend fun test2(): String
+                }
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) {
+            it.hasNoWarnings()
+            it.hasErrorCount(1)
+            it.hasErrorContaining(KtorGenLogger.ABSTRACT_FUNCTION_IGNORED.trim())
+        }
+    }
+
+    // -- annotations --
+    @Test
+    fun testPassAnnotationsGeneratedFunctionHaveThose() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGenFunction
+                import io.github.kingg22.ktorgen.http.GET
+
+                interface TestService {
+                    @KtorGenFunction(annotations = [org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class])
+                    @GET("posts")
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedAnnotationsText = "@ExperimentalCompilerApi"
+        val noExpectedAnnotationsText = "@OptIn(ExperimentalCompilerApi::class)"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generatedFile.contains(expectedAnnotationsText)
+            generatedFile.doesNotContain(noExpectedAnnotationsText)
+        }
+    }
+
+    @Test
+    fun testPassAnnotationsAndPropagateAnnotationGeneratedFunctionHaveThose() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGenFunction
+                import io.github.kingg22.ktorgen.http.GET
+
+                annotation class MyAnnotation
+
+                interface TestService {
+                    @KtorGenFunction(annotations = [org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class])
+                    @GET("posts")
+                    @MyAnnotation
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedAnnotationsText = listOf("@ExperimentalCompilerApi", "@MyAnnotation")
+        val noExpectedAnnotationsText = "@OptIn(ExperimentalCompilerApi::class)"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            for (expectedLine in expectedAnnotationsText) {
+                generatedFile.contains(expectedLine)
+            }
+            generatedFile.doesNotContain(noExpectedAnnotationsText)
+        }
+    }
+
+    // -- custom header kdoc --
+    @Test
+    fun testCustomHeaderOptionIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGenFunction
+                import io.github.kingg22.ktorgen.http.GET
+
+                interface TestService {
+                    @KtorGenFunction(customHeader = "Hello, World!")
+                    @GET("posts")
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedCustomHeaderText = "* Hello, World!"
+        val noExpectedCustomHeaderText = KTORG_GENERATED_COMMENT
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generatedFile.contains(expectedCustomHeaderText)
+            generatedFile.doesNotContain(noExpectedCustomHeaderText)
+        }
+    }
+
+    @Test
+    fun testDefaultCustomHeaderIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGenFunction
+                import io.github.kingg22.ktorgen.http.GET
+
+                interface TestService {
+                    @GET("posts")
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedCustomHeaderText = KTORG_GENERATED_COMMENT
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generatedFile.contains(expectedCustomHeaderText)
         }
     }
 }

--- a/compiler/src/test/kotlin/io/github/kingg22/ktorgen/KtorGenTest.kt
+++ b/compiler/src/test/kotlin/io/github/kingg22/ktorgen/KtorGenTest.kt
@@ -1,27 +1,109 @@
 package io.github.kingg22.ktorgen
 
 import androidx.room.compiler.processing.util.Source
+import io.github.kingg22.ktorgen.model.KTORG_GENERATED_FILE_COMMENT
 import kotlin.test.Test
 import kotlin.test.assertNull
 
 /** Test class only for [@KtorGen][io.github.kingg22.ktorgen.core.KtorGen] */
 class KtorGenTest {
+    // -- name --
+    @Test
+    fun defaultNameIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedNames = listOf("public class _TestServiceImpl", "public fun TestService")
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedNames.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    @Test
+    fun customNameOptionIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(name = "HelloWorldApi")
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        // the option name is only for custom class name, the function always have the name of the interface
+        // for customize functions, do manually!
+        val expectedNames = listOf("public class HelloWorldApi", "public fun TestService")
+        val nonExpectedNames = listOf("public class _TestServiceImpl")
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(
+                "com.example.api.HelloWorldApi".toRelativePath(),
+            )
+            expectedNames.forEach { line ->
+                generated.contains(line)
+            }
+            nonExpectedNames.forEach { line ->
+                generated.doesNotContain(line)
+            }
+        }
+    }
+
+    // -- generate? --
     @Test
     fun emptyInterfaceGeneratesNoOpFileWithoutErrors() {
         val api = Source.kotlin(
-            "foo.bar.EmptyApi.kt",
+            "Source.kt",
             """
-                package foo.bar
+                package com.example.api
 
                 import io.github.kingg22.ktorgen.core.KtorGen
 
                 @KtorGen
-                interface EmptyApi
+                interface TestService
             """.trimIndent(),
         )
 
+        val expectedText = listOf("public class _TestServiceImpl", ": TestService", "public fun TestService(")
+        val nonExpectedText = listOf("override")
+
         runKtorGenProcessor(api) { compilationResultSubject ->
             compilationResultSubject.hasErrorCount(0)
+            compilationResultSubject.hasNoWarnings()
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedText.forEach { line ->
+                generated.contains(line)
+            }
+            nonExpectedText.forEach { line ->
+                generated.doesNotContain(line)
+            }
         }
     }
 
@@ -48,6 +130,346 @@ class KtorGenTest {
         }
     }
 
+    // -- base path --
+    @Test
+    fun basePathIsAppendedToFunctions() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(basePath = "/api")
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedText = "this.takeFrom(".stringTemplate("/api") + ")"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+        }
+    }
+
+    @Test
+    fun emptyBasePathDontAppendAnything() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val nonExpectedText = "this.takeFrom("
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.doesNotContain(nonExpectedText)
+        }
+    }
+
+    /**
+     * In method like [io.github.kingg22.ktorgen.http.GET] you can put a template and complete it with parameters,
+     * the same apply to [basePath][io.github.kingg22.ktorgen.core.KtorGen.basePath],
+     * the method inheritance the full path and need be completed.
+     */
+    @Test
+    fun templateBasePathRequiredValueNotProvidedThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(basePath = "/api/{user}")
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(1)
+            compilationResultSubject.hasErrorContaining(KtorGenLogger.MISSING_PATH_VALUE)
+        }
+    }
+
+    @Test
+    fun invalidSyntaxOfPathThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(basePath = "/api/")
+                interface TestService {
+                    @GET("/user")
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(1)
+            compilationResultSubject.hasErrorContaining(KtorGenLogger.URL_SYNTAX_ERROR)
+        }
+    }
+
+    // -- top level factory function --
+    @Test
+    fun defaultFactoryFunctionIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(basePath = "/api/")
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val expectedText = "public fun TestService(httpClient: HttpClient): TestService = _TestServiceImpl(httpClient)"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+        }
+    }
+
+    @Test
+    fun optionFactoryFunctionFalseDontGeneratedThat() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(generateTopLevelFunction = false)
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val nonExpectedText = "public fun TestService(httpClient: HttpClient)"
+        val expectedText = "public class _TestServiceImpl"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+            generated.doesNotContain(nonExpectedText)
+        }
+    }
+
+    // -- companion extension function --
+    @Test
+    fun companionExtensionFunctionIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+
+                    @KtorGen(generateTopLevelFunction = true, generateCompanionExtFunction = true)
+                    companion object
+                }
+            """.trimIndent(),
+        )
+
+        val expectedText = listOf(
+            "public fun TestService(httpClient: HttpClient): TestService = _TestServiceImpl(httpClient)",
+            "public fun TestService.Companion.create(httpClient: HttpClient): TestService = _TestServiceImpl(httpClient)",
+            "public class _TestServiceImpl",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedText.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    /**
+     * A limitation of KSP is: can't alterate the source code,
+     * only generate new files, need explicit check exist companion object before generate invalid code
+     */
+    @Test
+    fun optionCompanionExtensionFunctionTrueAndNotHaveCompanionObjectThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(generateTopLevelFunction = true, generateCompanionExtFunction = true)
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(1)
+            compilationResultSubject.hasErrorContaining(KtorGenLogger.MISSING_COMPANION_TO_GENERATE.trim())
+        }
+    }
+
+    @Test
+    fun optionCompanionExtensionFunctionFalseDontGeneratedThat() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(generateTopLevelFunction = false, generateCompanionExtFunction = false)
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val nonExpectedText = "public fun TestService.Companion.create(httpClient: HttpClient)"
+        val expectedText = "public class _TestServiceImpl"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+            generated.doesNotContain(nonExpectedText)
+        }
+    }
+
+    // -- http client extension function --
+    @Test
+    fun optionHttpClientExtensionFunctionTrueGenerateThat() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(
+                    generateTopLevelFunction = true,
+                    generateCompanionExtFunction = true,
+                    generateHttpClientExtension = true,
+                )
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+
+                    companion object
+                }
+            """.trimIndent(),
+        )
+
+        val expectedText = listOf(
+            "public fun TestService(httpClient: HttpClient): TestService = _TestServiceImpl(httpClient)",
+            "public fun TestService.Companion.create(httpClient: HttpClient): TestService = _TestServiceImpl(httpClient)",
+            "public fun HttpClient.createTestService(): TestService = _TestServiceImpl(this)",
+            "public class _TestServiceImpl",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedText.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    @Test
+    fun optionHttpClientExtFunctionFalseDontGeneratedThat() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+                import io.github.kingg22.ktorgen.http.GET
+
+                @KtorGen(generateTopLevelFunction = false, generateHttpClientExtension = false)
+                interface TestService {
+                    @GET
+                    suspend fun test(): String
+                }
+            """.trimIndent(),
+        )
+
+        val nonExpectedText = "public fun HttpClient.create"
+        val expectedText = "public class _TestServiceImpl"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+            generated.doesNotContain(nonExpectedText)
+        }
+    }
+
+    // -- propagate annotations --
     @Test
     fun testOptInAnnotationIsPropagatedInClassGenerated() {
         val source = Source.kotlin(
@@ -112,6 +534,44 @@ class KtorGenTest {
         }
     }
 
+    // -- annotations --
+    @Test
+    fun optionAnnotationsGenerateCodeHaveThose() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @Target(AnnotationTarget.CLASS)
+                annotation class TestAnnotation
+
+                // empty target means all targets, annotation option respect it
+                annotation class MyAnnotation
+
+                @KtorGen(annotations = [TestAnnotation::class, MyAnnotation::class])
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedText = listOf(
+            "@TestAnnotation\n@MyAnnotation\n@Generated\npublic class _TestServiceImpl",
+            ": TestService",
+            "\n@Generated\n@MyAnnotation\npublic fun TestService(",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedText.forEach { line ->
+                generatedFile.contains(line)
+            }
+        }
+    }
+
+    // -- optIn annotation --
     @Test
     fun testRequiredOptInAnnotationIsPropagatedInClassGeneratedWithOptInOption() {
         val source = Source.kotlin(
@@ -144,6 +604,353 @@ class KtorGenTest {
             val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
             generatedFile.contains(expectedHeadersArgumentText)
             generatedFile.doesNotContain(noExpectedHeadersArgumentText)
+        }
+    }
+
+    // -- function annotations --
+    @Test
+    fun optionFunctionAnnotationsIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @Target(AnnotationTarget.FUNCTION)
+                annotation class TestAnnotation
+
+                // empty target means all targets, annotation option respect it
+                annotation class MyAnnotation
+
+                @KtorGen(functionAnnotations = [TestAnnotation::class, MyAnnotation::class])
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedText = listOf(
+            "\n@Generated\npublic class _TestServiceImpl",
+            ": TestService",
+            "\n@Generated\n@TestAnnotation\n@MyAnnotation\npublic fun TestService(",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generatedFile = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedText.forEach { line ->
+                generatedFile.contains(line)
+            }
+        }
+    }
+
+    // -- visibility modifier --
+    @Test
+    fun optionVisibilityModifierAllGeneratedCodeHaveIt() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(visibilityModifier = "internal")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedVisibility = listOf(
+            "internal class _TestServiceImpl",
+            "internal fun TestService(",
+            "internal constructor",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedVisibility.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    @Test
+    fun optionVisibilityModifierInvalidValueThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(visibilityModifier = "aksjdkajsdkjaskfh")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) {
+            it.hasErrorCount(1)
+            it.hasNoWarnings()
+            it.hasErrorContaining(KtorGenLogger.INVALID_VISIBILITY_MODIFIER.trim())
+        }
+    }
+
+    // -- class visibility modifier --
+    @Test
+    fun optionClassVisibilityIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(classVisibilityModifier = "PRIVATE")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedVisibility = listOf(
+            "private class _TestServiceImpl",
+            "public fun TestService(",
+            "public constructor", // can't be private because the function need instance it
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedVisibility.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    @Test
+    fun privateClassVisibilityWithoutFunctionThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(classVisibilityModifier = "PRIVATE", generateTopLevelFunction = false)
+                interface TestService
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(1)
+            compilationResultSubject.hasErrorContaining(KtorGenLogger.PRIVATE_CLASS_NO_ACCESS.trim())
+        }
+    }
+
+    // -- constructor visibility modifier --
+    @Test
+    fun optionConstructorVisibilityModifierIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(constructorVisibilityModifier = "internal")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedVisibility = listOf(
+            "public class _TestServiceImpl",
+            "public fun TestService(",
+            "internal constructor",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedVisibility.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    @Test
+    fun privateConstructorVisibilityThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(constructorVisibilityModifier = "private")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) {
+            it.hasErrorCount(1)
+            it.hasNoWarnings()
+            it.hasErrorContaining(KtorGenLogger.PRIVATE_CONSTRUCTOR.trim())
+        }
+    }
+
+    // -- function visibility modifier --
+    @Test
+    fun optionFunctionVisibilityModifierIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(functionVisibilityModifier = "INTERNAL")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedVisibility = listOf(
+            "public class _TestServiceImpl",
+            "internal fun TestService(",
+            "public constructor",
+        )
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasNoWarnings()
+            compilationResultSubject.hasErrorCount(0)
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            expectedVisibility.forEach { line ->
+                generated.contains(line)
+            }
+        }
+    }
+
+    @Test
+    fun privateFunctionVisibilityThrowsError() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(functionVisibilityModifier = "private")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        runKtorGenProcessor(source) {
+            it.hasErrorCount(1)
+            it.hasNoWarnings()
+            it.hasErrorContaining(KtorGenLogger.PRIVATE_FUNCTION.trim())
+        }
+    }
+
+    // -- custom File Header --
+    @Test
+    fun optionCustomFileHeaderIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(customFileHeader = "Hello, World!")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedText = "// Hello, World!"
+        val nonExpectedText = "// $KTORG_GENERATED_FILE_COMMENT"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasErrorCount(0)
+            compilationResultSubject.hasNoWarnings()
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+            generated.doesNotContain(nonExpectedText)
+        }
+    }
+
+    @Test
+    fun defaultCustomFileHeaderIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedText = "// $KTORG_GENERATED_FILE_COMMENT"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasErrorCount(0)
+            compilationResultSubject.hasNoWarnings()
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedText)
+        }
+    }
+
+    // -- custom class header --
+    @Test
+    fun optionCustomClassHeaderIsGenerated() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen(customClassHeader = "Hello, World")
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedHeader = "* Hello, World"
+        val nonExpectedHeader = "\n\n@Generated\npublic class"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasErrorCount(0)
+            compilationResultSubject.hasNoWarnings()
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedHeader)
+            generated.doesNotContain(nonExpectedHeader)
+        }
+    }
+
+    @Test
+    fun defaultCustomClassHeaderIsEmpty() {
+        val source = Source.kotlin(
+            "Source.kt",
+            """
+                package com.example.api
+
+                import io.github.kingg22.ktorgen.core.KtorGen
+
+                @KtorGen
+                interface TestService
+            """.trimIndent(),
+        )
+
+        val expectedHeader = "\n@Generated\npublic class"
+
+        runKtorGenProcessor(source) { compilationResultSubject ->
+            compilationResultSubject.hasErrorCount(0)
+            compilationResultSubject.hasNoWarnings()
+            val generated = compilationResultSubject.generatedSourceFileWithPath(TEST_SERVICE_IMPL_PATH)
+            generated.contains(expectedHeader)
         }
     }
 }

--- a/sample/src/commonMain/kotlin/MultiRoundApi.kt
+++ b/sample/src/commonMain/kotlin/MultiRoundApi.kt
@@ -1,0 +1,35 @@
+package io.github.kingg22.ktorgen.sample
+
+import io.github.kingg22.ktorgen.core.KtorGen
+import io.github.kingg22.ktorgen.core.KtorGenFunction
+import io.github.kingg22.ktorgen.http.*
+import kotlin.jvm.JvmSynthetic
+
+@KtorGen(
+    classVisibilityModifier = "private",
+    functionAnnotations = [JvmSynthetic::class],
+)
+internal interface MultiRoundApi {
+    @POST
+    @Header("Content-Type", "application/json")
+    @KtorGenFunction(annotations = [JvmSynthetic::class])
+    @JvmSynthetic
+    suspend fun getAlbumDiscography(
+        @Body jsonBody: String,
+        @Query("api_token") apiToken: String = "",
+        @Query("method") method: String = "album.getDiscography",
+        @Query("api_version") apiVersion: Float = 1.0f,
+        @Query input: Int = 3,
+    ): String
+
+    @POST
+    @Header("Content-Type", "application/json")
+    @KtorGenFunction(annotations = [JvmSynthetic::class])
+    suspend fun getAlbumData(
+        @Body jsonBody: String,
+        @Query("api_token") apiToken: String = "",
+        @Query("method") method: String = "album.getData",
+        @Query("api_version") apiVersion: Float = 1.0f,
+        @Query input: Int = 3,
+    ): String
+}


### PR DESCRIPTION
- Fix regression of early return on functions
- Fix logic of KtorGen option: annotations mean both, class and functions, now is extracted as the docs explain
- Add a catch for KSP exception when extract List<KSType> to KAnnotation
- Perf: remove NoOp generator, generate empty class with functions and others instead
- Add unit test for each property of KtorGen and KtorGenFunction
- Add as cause exception when diagnostic sender die.

## Resumen por Sourcery

Añade pruebas unitarias exhaustivas para todas las opciones de anotación KtorGen y KtorGenFunction, corrige regresiones en la generación de funciones y el manejo de anotaciones, y refactoriza los mappers y las utilidades de diagnóstico para mejorar la extracción de opciones y la notificación de errores.

Nuevas Características:
- Incluye un ejemplo de MultiRoundApi que demuestra el uso de KtorGen y KtorGenFunction

Correcciones de Errores:
- Restaura la generación de funciones eliminando la ruta de código NoOp
- Corrige la lógica de extracción de anotaciones para aplicar las anotaciones configuradas a clases y funciones
- Captura excepciones KSP de tipo no presente al mapear anotaciones

Mejoras:
- Refactoriza FunctionMapper y ClassMapper para centralizar la fusión de opciones y filtrar anotaciones por objetivo
- Mejora DiagnosticSender y DiagnosticTimer para llevar excepciones subyacentes en errores fatales
- Simplifica KotlinpoetGenerator para que siempre emita stubs de clase en lugar de una ruta de generador no-op

Compilación:
- Añade la dependencia kotlin-reflect

Pruebas:
- Añade pruebas unitarias que cubren cada propiedad y opción de KtorGen y KtorGenFunction

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add comprehensive unit tests for all KtorGen and KtorGenFunction annotation options, fix regressions in function generation and annotation handling, and refactor mappers and diagnostic utilities to improve option extraction and error reporting.

New Features:
- Include a sample MultiRoundApi demonstrating KtorGen and KtorGenFunction usage

Bug Fixes:
- Restore function generation by removing the NoOp code path
- Correct annotation extraction logic to apply configured annotations to classes and functions
- Catch KSP type-not-present exceptions when mapping annotations

Enhancements:
- Refactor FunctionMapper and ClassMapper to centralize option merging and filter annotations by target
- Enhance DiagnosticSender and DiagnosticTimer to carry underlying exceptions on fatal errors
- Simplify KotlinpoetGenerator to always emit class stubs instead of a no-op generator path

Build:
- Add kotlin-reflect dependency

Tests:
- Add unit tests covering each property and option of KtorGen and KtorGenFunction

</details>